### PR TITLE
Update GitSign workflow for commit verification

### DIFF
--- a/.github/workflows/gitsign-verify.yml
+++ b/.github/workflows/gitsign-verify.yml
@@ -1,11 +1,13 @@
 name: GitSign commit verification
 description: This action verifies the PR commit using Gitsign.
 on:
+  # Skip verification for Mend Renovate bot commits
   push:
-    branches: "**"
+    branches: 
+      - "*!renovate/**"
   pull_request:
-    branches: "**"
-
+    branches:
+      - "*!renovate/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +17,6 @@ permissions: {}
 
 jobs:
   gitSignVerify:
-    if: ${{ github.actor != 'renovate[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/gitsign-verify.yml
+++ b/.github/workflows/gitsign-verify.yml
@@ -1,9 +1,14 @@
-name: Verify Commit
+name: GitSign commit verification
 description: This action verifies the PR commit using Gitsign.
-on: [pull_request]
+on:
+  push:
+    branches: "**"
+  pull_request:
+    branches: "**"
+
 
 concurrency:
-  group: gitsign-verify
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 permissions: {}

--- a/.github/workflows/gitsign-verify.yml
+++ b/.github/workflows/gitsign-verify.yml
@@ -14,8 +14,11 @@ concurrency:
 permissions: {}
 
 jobs:
-  verify:
+  gitSignVerify:
+    if: ${{ github.actor != 'renovate[bot]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     name: Verify commit
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
Enhance the GitSign commit verification workflow by updating its name, adjusting trigger events to skip Renovate bot commits, and adding a timeout to improve efficiency and reduce overhead.

see https://github.com/orgs/community/discussions/6943

closes #70